### PR TITLE
Cleanup groups implementation

### DIFF
--- a/src/main/java/info/tehnut/armordisguise/ArmorDisguise.java
+++ b/src/main/java/info/tehnut/armordisguise/ArmorDisguise.java
@@ -10,9 +10,7 @@ import java.util.Set;
 public class ArmorDisguise implements ModInitializer {
 
     public static final String MODID = "armordisguise";
-    public static final Set<String> GROUPS = new ImmutableSet.Builder<String>().add(
-            "head", "chest", "legs", "feet"
-    ).build();
+    public static final Set<String> GROUPS = ImmutableSet.of("head", "chest", "legs", "feet");
 
     @Override
     public void onInitialize() {

--- a/src/main/java/info/tehnut/armordisguise/mixin/MixinArmorItem.java
+++ b/src/main/java/info/tehnut/armordisguise/mixin/MixinArmorItem.java
@@ -1,6 +1,7 @@
 package info.tehnut.armordisguise.mixin;
 
 import dev.emi.trinkets.api.ITrinket;
+import info.tehnut.armordisguise.ArmorDisguise;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ArmorItem;
 import org.spongepowered.asm.mixin.Final;
@@ -19,13 +20,8 @@ public class MixinArmorItem implements ITrinket {
         if (!group.equals(this.slot.getName()))
             return false;
 
-        switch (group) {
-            case "head":
-            case "chest":
-            case "legs":
-            case "feet":
-                return slot.equals("overlay");
-        }
+        if (ArmorDisguise.GROUPS.contains(group))
+            return "overlay".equals(slot);
 
         return false;
     }


### PR DESCRIPTION
Replaces ImmutableSet$Builder usage with ImmutableSet.of for the 4 group strings, and replaces the string switch in the item mixin with a contains check against the mod's groups.